### PR TITLE
Added a separator between day views on the Week View, and also a builder…

### DIFF
--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -163,6 +163,10 @@ class WeekViewStyle extends ZoomableHeaderWidgetStyle {
   /// A day view width.
   final double dayViewWidth;
 
+  /// The separator between the day views (see [ListView.separated]). Defaults to a
+  /// [VerticalDivider] with a width of exactly one device pixel.
+  final IndexedWidgetBuilder dayViewSeparatorBuilder;
+
   /// Creates a new week view style instance.
   const WeekViewStyle({
     DateFormatter dateFormatter,
@@ -175,6 +179,7 @@ class WeekViewStyle extends ZoomableHeaderWidgetStyle {
     Color hoursColumnBackgroundColor,
     double hourRowHeight,
     this.dayViewWidth,
+    this.dayViewSeparatorBuilder = DefaultBuilders.defaultDayViewSeparatorBuilder,
   }) : super(
           dateFormatter: dateFormatter,
           timeFormatter: timeFormatter,
@@ -199,6 +204,7 @@ class WeekViewStyle extends ZoomableHeaderWidgetStyle {
     Color hoursColumnBackgroundColor,
     double hourRowHeight,
     double dayViewWidth,
+    IndexedWidgetBuilder dayViewSeparatorBuilder,
   }) =>
       WeekViewStyle(
         dateFormatter: dateFormatter ?? this.dateFormatter,
@@ -211,5 +217,6 @@ class WeekViewStyle extends ZoomableHeaderWidgetStyle {
         hoursColumnBackgroundColor: hoursColumnBackgroundColor ?? this.hoursColumnBackgroundColor,
         hourRowHeight: hourRowHeight ?? this.hourRowHeight,
         dayViewWidth: dayViewWidth ?? this.dayViewWidth,
+        dayViewSeparatorBuilder: dayViewSeparatorBuilder ?? this.dayViewSeparatorBuilder,
       );
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -82,6 +82,11 @@ class DefaultBuilders {
     );
   }
 
+  /// Builds a day view separator for the week view widget.
+  static Widget defaultDayViewSeparatorBuilder(BuildContext context, int index) {
+    return const VerticalDivider(width: 0.0);
+  }
+
   /// Builds a date according to a list.
   static DateTime defaultDateCreator(List<DateTime> dates, int index) => dates[index];
 

--- a/lib/src/week_view.dart
+++ b/lib/src/week_view.dart
@@ -169,13 +169,14 @@ class _WeekViewState extends ZoomableHeadersWidgetState<WeekView> {
         children: [
           SizedBox(
             height: calculateHeight(),
-            child: ListView.builder(
+            child: ListView.separated(
               padding: EdgeInsets.only(left: widget.style.hoursColumnWidth),
               controller: widget.controller.horizontalScrollController,
               scrollDirection: Axis.horizontal,
               physics: widget.inScrollableWidget ? MagnetScrollPhysics(itemSize: dayViewWidth) : const NeverScrollableScrollPhysics(),
               itemCount: widget.dateCount,
               itemBuilder: (context, index) => createDayView(index),
+              separatorBuilder: (context, index) => widget.style.dayViewSeparatorBuilder(context, index),
             ),
           ),
           HoursColumn.fromHeadersWidgetState(parent: this),


### PR DESCRIPTION
…method in WeekViewStyle to customize it.

This adds a 1px VerticalDivider separating the DayViews in a WeekView. When the day view width is extended to fill the whole width available (default behaviour), this is almost the same as the previous rendering; but when the width is smaller than that (showing several days simultaneously on screen), I believe the separator makes it feel more tidy.