### PR TITLE
Fix subtraction logic error on HourMinute

### DIFF
--- a/lib/src/utils/hour_minute.dart
+++ b/lib/src/utils/hour_minute.dart
@@ -73,7 +73,10 @@ class HourMinute {
 
   /// Calculates the difference between this hour minute and another.
   HourMinute subtract(HourMinute other) {
-    int hour = math.max(this.hour - other.hour, 0);
+    int hour = this.hour - other.hour;
+    if(hour < 0) {
+      return HourMinute.ZERO;
+    }
     int minute = this.minute - other.minute;
     while (minute < 0) {
       if (hour == 0) {


### PR DESCRIPTION
Subtraction did not take account for subtractions where minutes of the subtracting HourMinute does not exceed that of the source HourDate. This code should fix that issue.

Example:
`HourMinute (hour: 0, minute: 36).subtract(HourMinute (hour: 1)`
Used to return `HourMinute (hour: 0, minute: 36)`
Now returns `HourMinute (hour: 0, minute: 0)` aka. `HourMinute.ZERO`