### PR TITLE
fix: potential scroll when scrollcontroller not attached

### DIFF
--- a/lib/src/widgets/week_view.dart
+++ b/lib/src/widgets/week_view.dart
@@ -189,7 +189,8 @@ class _WeekViewState extends ZoomableHeadersWidgetState<WeekView> {
   void scrollToInitialTime() {
     super.scrollToInitialTime();
 
-    if (horizontalScrollController == null) {
+    if (horizontalScrollController == null ||
+        !horizontalScrollController!.hasClients) {
       return;
     }
 
@@ -371,7 +372,7 @@ class _AutoScrollDayBar extends StatefulWidget {
   /// Creates a new positioned day bar instance.
   _AutoScrollDayBar({
     required _WeekViewState state,
-  })   : weekView = state.widget,
+  })  : weekView = state.widget,
         dayViewWidth = state.dayViewWidth!,
         stateScrollController = state.horizontalScrollController!,
         dayBarStyleBuilder = state.widget.dayBarStyleBuilder;


### PR DESCRIPTION
Fix potential scroll when scrollcontroller is currently not attached. 

That's the corresponding stacktrace:

```
The following assertion was thrown during a scheduler callback:
ScrollController not attached to any scroll views.
'package:flutter/src/widgets/scroll_controller.dart':
Failed assertion: line 108 pos 12: '_positions.isNotEmpty'

When the exception was thrown, this was the stack: 
#2      ScrollController.position (package:flutter/src/widgets/scroll_controller.dart:108:12)
#3      _WeekViewState.scrollToInitialTime (package:flutter_week_view/src/widgets/week_view.dart:199:49)
#4      ZoomableHeadersWidgetState.scheduleScrollToInitialTime.<anonymous closure> (package:flutter_week_view/src/widgets/zoomable_header_widget.dart:162:41)
#5      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1144:15)
#6      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1090:9)
```