### PR TITLE
Fix resize not updating events correctly

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -262,7 +262,6 @@ class _DynamicDayViewState extends State<_DynamicDayView> {
 
   /// Updates [oldEvent] to [newEvent].
   void updateEvent(FlutterWeekViewEvent oldEvent, FlutterWeekViewEvent newEvent) {
-    List<FlutterWeekViewEvent> events = List.of(this.events);
     int index = events.indexOf(oldEvent);
     if (index >= 0) {
       events[index] = newEvent;

--- a/lib/src/widgets/day_view.dart
+++ b/lib/src/widgets/day_view.dart
@@ -273,8 +273,8 @@ class _DayViewState<E extends FlutterWeekViewEventMixin> extends ZoomableHeaders
         // We restore the original event.end in order to pass the unchanged
         // event in the callback.
         DateTime newEventEnd = event.end;
-        setState(() => updateEvent(event, event.copyWith(end: originalResizeEventEnd)));
-        widget.resizeEventOptions!.onEventResized(event, newEventEnd);
+        setState(() => updateEvent(event, event.copyWith(end: newEventEnd)));
+        widget.resizeEventOptions!.onEventResized(event.copyWith(end: originalResizeEventEnd), newEventEnd);
       },
       onVerticalDragUpdate: (details) {
         if (event is! CopyableEvent<E>) {
@@ -391,7 +391,6 @@ class _DayViewState<E extends FlutterWeekViewEventMixin> extends ZoomableHeaders
 
   /// Updates [oldEvent] to [newEvent].
   void updateEvent(E oldEvent, E newEvent) {
-    List<E> events = List.of(this.events);
     int index = events.indexOf(oldEvent);
     if (index >= 0) {
       events[index] = newEvent;


### PR DESCRIPTION
`[√] Flutter (Channel stable, 3.38.2, on Microsoft Windows [Version 10.0.26200.7309], locale en-SE)`

Running the latest main and trying the example project's dynamic day view on Microsoft Edge does not allow resizing of events. 


The callback in the resize for the DayView widget previously reported the same time for the `event` and the `newEndTime`.

`onEventResized: (FlutterWeekViewEvent event, DateTime newEndTime) `

This change fixes so that 
* The `updateEvent` method no longer makes a copy before making changes
* The resize event now updates the event and passes the previous `event` (unchanged) and the resize drop point `newEndTime`
